### PR TITLE
Fix to wrong output in the files 'full_mcmc.dat'

### DIFF
--- a/nstar-mcmc.f
+++ b/nstar-mcmc.f
@@ -1736,9 +1736,6 @@ C        EE0 = EE0 + EXP(((SSEP-26.35)/(5.49))**2)!SSEP Constraint Here
          CLOSE(26)
         ELSE
         ENDIF
-        WRITE(24,*) X1MIN,Y1MIN,X2MIN,Y2MIN,X3MIN,Y3MIN,
-     .  LSSEPMIN,BSEPMIN,FMIN,FBMIN,
-     .  ZM,((IFM*.001)*(ZM)),((1-IFM*.001)*(ZM)),((IFBM*.001)*(ZM)),EEM
       IF (EEM .LE. EE0) THEN
         IX10 = IX1M
         IX20 = IX2M
@@ -1784,6 +1781,9 @@ C        EE0 = EE0 + EXP(((SSEP-26.35)/(5.49))**2)!SSEP Constraint Here
      .  ZM,((IFM*.001)*(ZM)),((1-IFM*.001)*(ZM)),((IFBM*.001)*(ZM)),EEM
       ENDIF
       ENDIF
+      WRITE(24,*) IX10,IY10,IX20,IY20,IX30,IY30,
+      LSSEP,BSEP,IF0*0.001,IFB0*0.001,Z0,
+      ((IF0*.001)*(Z0)),((1-IF0*.001)*(Z0)),((IFB0*.001)*(Z0)),EE0
       IF (MOD(IT,50000)==0) WRITE(*,"(I6.2)") IT
       ENDDO !End main MCMC iteration
        WRITE(*,*) "Acceptance Rate = ", ACC_ARRAY/Steps

--- a/nstar-mcmc.f
+++ b/nstar-mcmc.f
@@ -1243,7 +1243,6 @@ C--------------------------------------------------------------
          CLOSE(26)
         ELSE
         ENDIF
-        WRITE(24,*) X1MIN,Y1MIN,ZMIN,EMIN
       IF (EEM .LE. EE0) THEN
         IX10 = IX1M
         IY10 = IY1M
@@ -1273,6 +1272,7 @@ C--------------------------------------------------------------
         WRITE(25,*) X1,Y1,ZM,EEM
       ENDIF
       ENDIF
+      WRITE(24,*) IX10,IY10,Z0,EE0
       IF (MOD(IT,50000)==0) WRITE(*,"(I6.2)") IT
       ENDDO !End main MCMC iteration
        WRITE(*,*) "Acceptance Rate = ", ACC_ARRAY/Steps

--- a/nstar-mcmc.f
+++ b/nstar-mcmc.f
@@ -1470,8 +1470,6 @@ C        EEM = EEM + EXP(((SSEP-100.0)/(15.73))**2)!SSEP Constraint Here
          CLOSE(26)
         ELSE
         ENDIF
-        WRITE(24,*) X1MIN,Y1MIN,X2MIN,Y2MIN,SSEPMIN,FMIN,ZMIN,
-     . ((FMIN)*(ZMIN)), ((1-FMIN)*(ZMIN)),EMIN 
       IF (EEM .LE. EE0) THEN
         IX10 = IX1M
         IX20 = IX2M
@@ -1509,6 +1507,8 @@ C        EEM = EEM + EXP(((SSEP-100.0)/(15.73))**2)!SSEP Constraint Here
      .  ((IFM*.001)*(ZM)), ((1-IFM*.001)*(ZM)),EEM
         ENDIF
       ENDIF
+      WRITE(24,*) IX10,IY10,IX20,IY20,SSEP,IF0*0.001,Z0,
+     .  ((IF0*.001)*(Z0)), ((1-IF0*.001)*(Z0)),EE0
       IF (MOD(IT,50000)==0) WRITE(*,"(I8.2)") IT
       ENDDO !End main MCMC iteration
        WRITE(*,*) "Acceptance Rate = ", ACC_ARRAY/Steps


### PR DESCRIPTION
The output to the file 'full_mcmc.dat' was not at the right position in the MCMC loop, nor were the output variables. I corrected that for the 1-star, 2-star and 3-star fit. I extensively tested the code on a 2-star fit, but not for the 1-star and 3-star fits. The "accepted_mcmc.dat" file and "full_mcmc.dat" are now consistent one each other.